### PR TITLE
fix: make product search case-insensitive

### DIFF
--- a/packages/api/src/products/getProducts.ts
+++ b/packages/api/src/products/getProducts.ts
@@ -33,6 +33,7 @@ export const getProducts = publicProcedure
     if (name) {
       whereClause.name = {
         contains: name,
+        mode: "insensitive",
       };
     }
 


### PR DESCRIPTION
https://github.com/theodevoid/mikrommerce/issues/14

https://www.prisma.io/docs/concepts/components/prisma-client/case-sensitivity

add `mode: 'insensitive' in `whereClause` prisma `getProducts` public procedure